### PR TITLE
1.1.7Av

### DIFF
--- a/src/filman_discord/endpoints/info.py
+++ b/src/filman_discord/endpoints/info.py
@@ -14,7 +14,7 @@ async def info_command(ctx: lightbulb.SlashContext) -> None:
 
     embed.add_field(
         name="Wersja i ostatnia aktualizacja",
-        value="`1.1.8` - `2024-12-03`",
+        value="`1.1.7Av` - `2024-12-04`",
     )
 
     embed.add_field(

--- a/src/filman_discord/endpoints/info.py
+++ b/src/filman_discord/endpoints/info.py
@@ -14,7 +14,7 @@ async def info_command(ctx: lightbulb.SlashContext) -> None:
 
     embed.add_field(
         name="Wersja i ostatnia aktualizacja",
-        value="`1.1.7` - `2024-12-03`",
+        value="`1.1.8` - `2024-12-03`",
     )
 
     embed.add_field(

--- a/src/filman_server/main.py
+++ b/src/filman_server/main.py
@@ -56,7 +56,6 @@ async def trigger_error():
 
 if __name__ == "__main__":
     logging.info("Filman server started")
-    uvicorn.run(app, host="0.0.0.0", port=8000)
-    logging.debug("uvicorn running")
     cron.start()
     logging.debug("cron running")
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
Fixed logic behind cron

### Server Startup Logging:
* [`src/filman_server/main.py`](diffhunk://#diff-47fd75b083c034c9d8186d95efd0218178f2a38f8c68092b15c82caae0c6b14cL59-R61): Adjusted the order of operations in the main script to ensure `uvicorn.run` is called after starting the cron job, removing a redundant logging statement.